### PR TITLE
mark-devkit: Bump sci-libs/colamd-3.3.3-r1

### DIFF
--- a/sci-libs/colamd/colamd-3.3.3-r1.ebuild
+++ b/sci-libs/colamd/colamd-3.3.3-r1.ebuild
@@ -31,7 +31,6 @@ src_configure() {
 }
 
 src_install() {
-	cmake_src_install
 	rm -f "${ED}"/usr/include/suitesparse/SuiteSparse_config.h \
         "${ED}"/usr/lib64/cmake/SuiteSparse/*.cmake \
         "${ED}"/usr/lib64/cmake/SuiteSparse_config/*.cmake \


### PR DESCRIPTION
Automatic bump of package sci-libs/colamd-3.3.3-r1 for branch mark-unstable by mark-bot