### PR TITLE
mark-devkit: Bump sci-mathematics/lpsolve-5.5.2.0-r1

### DIFF
--- a/sci-mathematics/lpsolve/lpsolve-5.5.2.0-r1.ebuild
+++ b/sci-mathematics/lpsolve/lpsolve-5.5.2.0-r1.ebuild
@@ -16,7 +16,6 @@ DEPEND="sci-libs/colamd"
 RDEPEND="${DEPEND}"
 
 src_configure() {
-	export CFLAGS="${CFLAGS} -I/usr/include/suitesparse"
 	econf \
 		$(use_enable static-libs static)
 }


### PR DESCRIPTION
Automatic bump of package sci-mathematics/lpsolve-5.5.2.0-r1 for branch mark-iii by mark-bot