### PR TITLE
mark-devkit: [mark-31] Bump sci-mathematics/z3-4.8.5-r1

### DIFF
--- a/sci-mathematics/z3/z3-4.8.5-r1.ebuild
+++ b/sci-mathematics/z3/z3-4.8.5-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python3+ )
+PYTHON_COMPAT=( python{2_7,3_{5,6,7}} )
 
 inherit cmake-multilib python-single-r1 toolchain-funcs
 


### PR DESCRIPTION
Automatic bump of package sci-mathematics/z3-4.8.5-r1 for branch mark-31 by mark-bot